### PR TITLE
significantly optimize temp frame creation

### DIFF
--- a/lib/extract-video-frames.js
+++ b/lib/extract-video-frames.js
@@ -5,14 +5,23 @@ const ffmpeg = require('fluent-ffmpeg')
 module.exports = (opts) => {
   const {
     videoPath,
-    framePattern
+    framePattern,
+    seek,
+    duration,
+    fps
   } = opts
 
   return new Promise((resolve, reject) => {
-    ffmpeg(videoPath)
+    const cmd = ffmpeg(videoPath)
+
+    if (seek) cmd.seek(seek / 1000)
+    if (duration) cmd.setDuration(duration / 1000)
+
+    cmd
       .outputOptions([
         '-pix_fmt', 'rgba',
-        '-start_number', '0'
+        '-start_number', '0',
+        '-r', fps
       ])
       .output(framePattern)
       .on('start', (cmd) => console.log({ cmd }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,8 @@ module.exports = async (opts) => {
   try {
     console.time(`init-frames`)
     const {
-      frames,
+      renders,
+      scenes,
       theme
     } = await initFrames({
       log,
@@ -44,12 +45,12 @@ module.exports = async (opts) => {
     console.timeEnd(`init-frames`)
 
     console.time(`render-frames`)
-    const framePattern = await renderFrames({
+    const framePatterns = await renderFrames({
       log,
       concurrency,
       outputDir: temp,
       frameFormat,
-      frames,
+      renders,
       theme,
       onProgress: (p) => {
         log(`render ${(100 * p).toFixed()}%`)
@@ -60,10 +61,11 @@ module.exports = async (opts) => {
     console.time(`transcode-video`)
     await transcodeVideo({
       log,
-      framePattern,
+      framePatterns,
       frameFormat,
       audio,
       output,
+      scenes,
       theme,
       onProgress: (p) => {
         log(`transcode ${(100 * p).toFixed()}%`)

--- a/lib/init-frames.js
+++ b/lib/init-frames.js
@@ -25,13 +25,10 @@ module.exports = async (opts) => {
 
   const scenes = await pMap(videos, (video, index) => {
     return module.exports.initScene({
-      log,
       index,
       videos,
       transition,
-      transitions,
-      frameFormat,
-      outputDir
+      transitions
     })
   }, {
     concurrency
@@ -46,6 +43,13 @@ module.exports = async (opts) => {
 
   const frames = []
   let numFrames = 0
+
+  for (let i = 0; i < scenes.length; ++i) {
+    const scene = scenes[i]
+    const next = (i < scenes.length - 1 ? scenes[i + 1] : undefined)
+
+    // TODO TODO TODO
+  }
 
   scenes.forEach((scene, index) => {
     scene.frameStart = numFrames
@@ -88,13 +92,10 @@ module.exports = async (opts) => {
 
 module.exports.initScene = async (opts) => {
   const {
-    log,
     index,
     videos,
     transition,
-    transitions,
-    frameFormat,
-    outputDir
+    transitions
   } = opts
 
   const video = videos[index]
@@ -106,10 +107,9 @@ module.exports.initScene = async (opts) => {
     width: probe.width,
     height: probe.height,
     duration: probe.duration,
+    fps: probe.fps,
     numFrames: parseInt(probe.streams[0].nb_frames)
   }
-
-  scene.fps = probe.fps
 
   const t = (transitions ? transitions[index] : transition)
   scene.transition = {
@@ -122,6 +122,17 @@ module.exports.initScene = async (opts) => {
   if (index >= videos.length - 1) {
     scene.transition.duration = 0
   }
+
+  return scene
+}
+
+module.exports.initSceneFrames = async (scene, opts) => {
+  const {
+    log,
+    index,
+    frameFormat,
+    outputDir
+  } = opts
 
   const fileNamePattern = `scene-${index}-%012d.${frameFormat}`
   const framePattern = path.join(outputDir, fileNamePattern)

--- a/lib/init-frames.js
+++ b/lib/init-frames.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const ffmpegProbe = require('ffmpeg-probe')
-const fs = require('fs-extra')
 const leftPad = require('left-pad')
 const path = require('path')
 const pMap = require('p-map')
@@ -41,47 +40,68 @@ module.exports = async (opts) => {
     fps
   } = scenes[0]
 
-  const frames = []
-  let numFrames = 0
+  const renders = []
 
   for (let i = 0; i < scenes.length; ++i) {
+    const prev = scenes[i - 1]
     const scene = scenes[i]
-    const next = (i < scenes.length - 1 ? scenes[i + 1] : undefined)
+    const next = scenes[i + 1]
 
-    // TODO TODO TODO
-  }
+    scene.trimStart = (prev ? prev.transition.duration : 0)
 
-  scenes.forEach((scene, index) => {
-    scene.frameStart = numFrames
+    // sanitize transition durations to never be longer than scene durations
+    scene.transition.duration = Math.max(0, Math.min(scene.transition.duration, scene.duration - scene.trimStart))
 
-    scene.numFramesTransition = Math.floor(scene.transition.duration * fps / 1000)
-    scene.numFramesPreTransition = Math.max(0, scene.numFrames - scene.numFramesTransition)
-
-    numFrames += scene.numFramesPreTransition
-
-    for (let frame = 0; frame < scene.numFrames; ++frame) {
-      const cFrame = scene.frameStart + frame
-
-      if (!frames[cFrame]) {
-        const next = (frame < scene.numFramesPreTransition ? undefined : scenes[index + 1])
-
-        frames[cFrame] = {
-          current: scene,
-          next
-        }
-      }
+    if (next) {
+      scene.transition.duration = Math.min(scene.transition.duration, next.duration)
     }
-  })
+
+    scene.trimEnd = scene.duration - (next ? scene.transition.duration : 0)
+    scene.trimDuration = scene.trimEnd - scene.trimStart
+
+    if (next) {
+      const sceneGetFrame = await module.exports.initFrames({
+        log,
+        prefix: `post-${i}`,
+        frameFormat,
+        outputDir,
+        videoPath: scene.video,
+        seek: scene.trimEnd,
+        duration: scene.transition.duration,
+        fps
+      })
+
+      const nextGetFrame = await module.exports.initFrames({
+        log,
+        prefix: `pre-${i}`,
+        frameFormat,
+        outputDir,
+        videoPath: next.video,
+        seek: 0,
+        duration: scene.transition.duration,
+        fps
+      })
+
+      const numFrames = Math.floor(scene.transition.duration * fps / 1000)
+
+      renders.push({
+        scene,
+        next,
+        numFrames,
+        sceneGetFrame,
+        nextGetFrame
+      })
+    }
+  }
 
   const duration = scenes.reduce((sum, scene, index) => (
     scene.duration + sum - scene.transition.duration
   ), 0)
 
   return {
-    frames,
+    renders,
     scenes,
     theme: {
-      numFrames,
       duration,
       width,
       height,
@@ -126,37 +146,30 @@ module.exports.initScene = async (opts) => {
   return scene
 }
 
-module.exports.initSceneFrames = async (scene, opts) => {
+module.exports.initFrames = async (opts) => {
   const {
     log,
-    index,
+    prefix,
     frameFormat,
-    outputDir
+    outputDir,
+    videoPath,
+    seek,
+    duration,
+    fps
   } = opts
 
-  const fileNamePattern = `scene-${index}-%012d.${frameFormat}`
+  const fileNamePattern = `scene-${prefix}-%012d.${frameFormat}`
   const framePattern = path.join(outputDir, fileNamePattern)
   await extractVideoFrames({
     log,
-    videoPath: scene.video,
-    framePattern
+    videoPath,
+    framePattern,
+    seek,
+    duration,
+    fps
   })
 
-  scene.getFrame = (frame) => {
+  return (frame) => {
     return framePattern.replace('%012d', leftPad(frame, 12, '0'))
   }
-
-  // guard to ensure we only use frames that exist
-  while (scene.numFrames > 0) {
-    const frame = scene.getFrame(scene.numFrames - 1)
-    const exists = await fs.pathExists(frame)
-
-    if (exists) {
-      break
-    } else {
-      scene.numFrames--
-    }
-  }
-
-  return scene
 }

--- a/lib/render-frames.js
+++ b/lib/render-frames.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fs = require('fs-extra')
 const leftPad = require('left-pad')
 const path = require('path')
 const pMap = require('p-map')
@@ -10,80 +9,95 @@ const createContext = require('./context')
 module.exports = async (opts) => {
   const {
     frameFormat,
-    frames,
-    onProgress,
+    renders,
+    // onProgress,
     outputDir,
     theme
   } = opts
 
-  const ctx = await createContext({
-    frameFormat,
-    theme
-  })
+  // how many transitions to render concurrently
+  let concurrency = 4
+  let contexts = []
 
-  await pMap(frames, (frame, index) => {
-    return module.exports.renderFrame({
-      ctx,
-      frame,
+  for (let i = 0; i < concurrency; ++i) {
+    const ctx = await createContext({
       frameFormat,
-      index,
-      onProgress,
-      outputDir,
       theme
     })
+
+    contexts.push(ctx)
+  }
+
+  const framePatterns = await pMap(renders, async (render, index) => {
+    const ctx = contexts.pop()
+    const framePattern = await module.exports.renderTransition({
+      ctx,
+      render,
+      frameFormat,
+      index,
+      outputDir
+    })
+
+    contexts.push(ctx)
+    return framePattern
   }, {
-    concurrency: 8
+    concurrency
   })
 
-  await ctx.flush()
-  await ctx.dispose()
+  for (let i = 0; i < contexts.length; ++i) {
+    const ctx = contexts[i]
+    await ctx.flush()
+    await ctx.dispose()
+  }
 
-  const framePattern = path.join(outputDir, `%012d.${frameFormat}`)
-  return framePattern
+  return framePatterns
 }
 
-module.exports.renderFrame = async (opts) => {
+module.exports.renderTransition = async (opts) => {
   const {
     ctx,
-    frame,
+    render,
     frameFormat,
     index,
     onProgress,
-    outputDir,
-    theme
+    outputDir
   } = opts
 
-  const fileName = `${leftPad(index, 12, '0')}.${frameFormat}`
-  const filePath = path.join(outputDir, fileName)
-
   const {
-    current,
-    next
-  } = frame
+    scene,
+    numFrames,
+    sceneGetFrame,
+    nextGetFrame
+  } = render
 
-  const cFrame = index - current.frameStart
-  const cFramePath = current.getFrame(cFrame)
+  ctx.setTransition(scene.transition)
 
-  if (!next) {
-    await fs.move(cFramePath, filePath, { overwrite: true })
-  } else {
-    ctx.setTransition(current.transition)
+  for (let frame = 0; frame < numFrames; ++frame) {
+    const fileName = `render-${index}-${leftPad(frame, 12, '0')}.${frameFormat}`
+    const filePath = path.join(outputDir, fileName)
 
-    const nFrame = index - next.frameStart
-    const nFramePath = next.getFrame(nFrame)
-    const cProgress = (cFrame - current.numFramesPreTransition) / current.numFramesTransition
+    const progress = frame / numFrames
 
-    await ctx.render({
-      imagePathFrom: cFramePath,
-      imagePathTo: nFramePath,
-      progress: cProgress,
-      params: current.transition.params
-    })
+    try {
+      await ctx.render({
+        imagePathFrom: sceneGetFrame(frame),
+        imagePathTo: nextGetFrame(frame),
+        progress: progress,
+        params: scene.transition.params
+      })
+    } catch (err) {
+      // stop at the first missing frame
+      // TODO: output info in debug mode
+      break
+    }
 
     await ctx.capture(filePath)
+
+    if (onProgress && frame % 8 === 0) {
+      // TODO: re-add onProgress
+      onProgress(progress)
+    }
   }
 
-  if (onProgress && index % 16 === 0) {
-    onProgress(index / theme.numFrames)
-  }
+  return path.join(outputDir, `render-${index}-%012d.${frameFormat}`)
 }

--- a/lib/transcode-video.js
+++ b/lib/transcode-video.js
@@ -8,9 +8,10 @@ module.exports = async (opts) => {
     log,
     audio,
     frameFormat,
-    framePattern,
+    framePatterns,
     onProgress,
     output,
+    scenes,
     theme
   } = opts
 
@@ -27,12 +28,41 @@ module.exports = async (opts) => {
       ])
     }
 
-    const cmd = ffmpeg(framePattern)
-      .inputOptions(inputOptions)
+    const cmd = ffmpeg()
 
-    if (audio) {
-      cmd.addInput(audio)
+    // construct complex filter graph for concat
+    const n = scenes.length
+    let filter = ''
+    let postFilter = ''
+    for (let i = 0; i < n; ++i) {
+      const scene = scenes[i]
+      const transition = framePatterns[i]
+
+      const v0 = i * 2
+      cmd.addInput(scene.video)
+
+      filter += `[${v0}:v]trim=${scene.trimStart / 1000}:${scene.trimEnd / 1000}[t${v0}];[t${v0}]setpts=PTS-STARTPTS[v${v0}];`
+      postFilter += `[v${v0}]`
+
+      if (transition) {
+        const v1 = i * 2 + 1
+        cmd.addInput(transition)
+        cmd.inputOptions(inputOptions)
+
+        postFilter += `[${v1}:v]`
+      }
     }
+
+    const chain = `${filter}${postFilter}concat=n=${n * 2 - 1}[outv]`
+    if (audio) cmd.addInput(audio)
+
+    cmd.addOptions([
+      '-filter_complex', chain,
+      '-map', '[outv]'
+    ].concat(audio
+      ? [ '-map', `${n * 2}` ]
+      : [ ]
+    ))
 
     const outputOptions = []
       // misc


### PR DESCRIPTION
This PR implements the approach discussed in #8, namely it makes a tradeoff between compute time versus temp storage requirements that should make the program more robust for larger videos.

Previously, we extracted all frames from each input video, then rendered the transitions where appropriate, then did a final transcoding pass that was very efficient since it only had one input source.

Now, we will only ever extract frames from input videos that are used in the transitions, which for larger input videos can be a significant reduction in temp frames extracted. This has the disadvantage, however, that the final transcoding phase is more complex and involves O(n) inputs instead of O(1) inputs.

If we decide to merge this approach, it will necessitate a major version bump to `v2.0.0`.

I would like to gather some performance numbers for speed and memory usage before committing to this approach.  In my very preliminary tests, the speed has remained approximately the same with a significant reduction in temporary disk and memory usage, though I'm guessing that we should expect speed improvements from longer / larger video inputs.

@BrandonCookeDev, @daniel-habib, I'm guessing these changes will interest you.  Thoughts & feedback are more than welcome.