### PR TITLE
Replace ffmpeg-probe with fluent-ffmpeg

### DIFF
--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('ava')
-const ffmpegProbe = require('ffmpeg-probe')
+const ffmpeg = require('fluent-ffmpeg')
 const path = require('path')
 const rmfr = require('rmfr')
 const tempy = require('tempy')
@@ -20,6 +20,15 @@ const videosWithAudio = [
   path.join(fixturesPath, '0a.mp4')
 ]
 
+async function ffprobeAsync(file) {
+  return new Promise((resolve, reject) => {
+    ffmpeg.ffprobe(file, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
+}
+
 test.serial('concat 3 mp4s with using constant 500ms transitions', async (t) => {
   const output = tempy.file({ extension: 'mp4' })
   await concat({
@@ -33,11 +42,13 @@ test.serial('concat 3 mp4s with using constant 500ms transitions', async (t) => 
     }
   })
 
-  const probe = await ffmpegProbe(output)
-  t.is(probe.width, 640)
-  t.is(probe.height, 360)
-  t.truthy(probe.duration >= 10500)
-  t.truthy(probe.duration <= 11500)
+  const probe = await ffprobeAsync(output)
+  console.log(probe);
+  const videoStream = probe.streams.find(stream => stream.codec_type === 'video')
+  t.is(videoStream.width, 640)
+  t.is(videoStream.height, 360)
+  t.truthy(probe.format.duration >= 10.5)
+  t.truthy(probe.format.duration <= 11.5)
 
   await rmfr(output)
 })
@@ -85,40 +96,45 @@ test.serial('concat 9 mp4s with unique transitions', async (t) => {
     ]
   })
 
-  const probe = await ffmpegProbe(output)
-  t.is(probe.width, 640)
-  t.is(probe.height, 360)
-  t.truthy(probe.duration >= 27000)
-  t.truthy(probe.duration <= 28000)
+  const probe = await ffprobeAsync(output)
+  console.log(probe);
+  const videoStream = probe.streams.find(stream => stream.codec_type === 'video')
+  t.is(videoStream.width, 640)
+  t.is(videoStream.height, 360)
+  t.truthy(probe.format.duration >= 27)
+  t.truthy(probe.format.duration <= 28)
 
   await rmfr(output)
 })
 
 test.serial('concat 3 mp4s with source audio and unique transitions', async (t) => {
-  const output = tempy.file({ extension: 'mp4' })
-  await concat({
-    log: console.log,
-    verbose: true,
-    output,
-    videos: videosWithAudio,
-    transitions: [
-      {
-        name: 'circleOpen',
-        duration: 1000
-      },
-      {
-        name: 'crossWarp',
-        duration: 1000
-      }
-    ]
-  })
+const output = tempy.file({ extension: 'mp4' })
+await concat({
+log: console.log,
+verbose: true,
+output,
+videos: videosWithAudio,
+transitions: [
+{
+name: 'circleOpen',
+duration: 1000
+},
+{
+name: 'crossWarp',
+duration: 1000
+}
+]
+})
 
-  const probe = await ffmpegProbe(output)
-  t.is(probe.width, 1280)
-  t.is(probe.height, 720)
-  t.is(probe.streams.length, 2)
-  t.truthy(probe.duration >= 11000)
-  t.truthy(probe.duration <= 15000)
+const probe = await ffprobeAsync(output)
+console.log(probe);
+const videoStream = probe.streams.find(stream => stream.codec_type === 'video')
+const audioStream = probe.streams.find(stream => stream.codec_type === 'audio')
+t.is(videoStream.width, 1280)
+t.is(videoStream.height, 720)
+t.is(probe.streams.length, 2)
+t.truthy(probe.format.duration >= 11)
+t.truthy(probe.format.duration <= 15)
 
-  await rmfr(output)
+await rmfr(output)
 })

--- a/lib/init-frames.js
+++ b/lib/init-frames.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ffmpegProbe = require('ffmpeg-probe')
+const ffmpeg = require('fluent-ffmpeg')
 const fs = require('fs-extra')
 const leftPad = require('left-pad')
 const path = require('path')
@@ -114,29 +114,34 @@ module.exports.initScene = async (opts) => {
   } = opts
 
   const video = videos[index]
-  const probe = await ffmpegProbe(video)
-  const format = (probe.format && probe.format.format_name) || 'unknown'
+  const probe = await ffprobeAsync(video)
+  const format = (probe.format && probe.format.tags && probe.format.tags.major_brand) || 'unknown';
 
-  if (!probe.streams || !probe.streams[0]) {
+  console.log("Probe object:", probe);
+
+  if (!probe.streams || !probe.streams[0] || probe.streams[0].codec_type !== 'video') {
     throw new Error(`Unsupported input video format "${format}": ${video}`)
   }
+
+
+  const videoStream = probe.streams.find((stream) => stream.codec_type === 'video');
 
   const scene = {
     video,
     index,
-    width: probe.width,
-    height: probe.height,
-    duration: probe.duration,
-    numFrames: parseInt(probe.streams[0].nb_frames),
-    fps: probe.fps
-  }
+    width: videoStream.width,
+    height: videoStream.height,
+    duration: parseFloat(probe.format.duration),
+    numFrames: parseInt(videoStream.nb_frames),
+    fps: parseFloat(videoStream.avg_frame_rate)
+  };
 
   if (isNaN(scene.numFrames) || isNaN(scene.duration)) {
-    throw new Error(`Unsupported input video format "${format}": ${video}`)
+    throw new Error(`Unsupported input video format "${format}": ${video}`);
   }
 
   if (verbose) {
-    console.error(scene)
+    console.error(scene);
   }
 
   const t = transitions ? transitions[index] : transition
@@ -202,4 +207,13 @@ module.exports.initScene = async (opts) => {
   }
 
   return scene
+}
+
+async function ffprobeAsync(file) {
+  return new Promise((resolve, reject) => {
+    ffmpeg.ffprobe(file, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
 }


### PR DESCRIPTION
Fluent allows the same probe functionality, and allows you to set a specific probe path, I think using fluent for both makes the most sense! (let me know if I'm missing some factor to this not being possible, thanks!)
